### PR TITLE
feat(database): add connection pool configuration options

### DIFF
--- a/database/service.go
+++ b/database/service.go
@@ -3,6 +3,7 @@ package database
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -17,8 +18,12 @@ type Service struct {
 }
 
 const (
-	DefaultTrustServerCertificate string = "true"
-	DefaultTransportEncrypt       string = "enabled"
+	DefaultTrustServerCertificate string        = "true"
+	DefaultTransportEncrypt       string        = "enabled"
+	DefaultMaxOpenConns           int           = 20
+	DefaultMaxIdleConns           int           = 5
+	DefaultConnMaxLifetime        time.Duration = time.Hour
+	DefaultConnMaxIdleTime        time.Duration = 30 * time.Minute
 )
 
 type ConnectionConfig struct {
@@ -35,6 +40,12 @@ type ConnectionConfig struct {
 
 	// not used on `sqlite` driver
 	TransportEncrypt string
+
+	// Connection pool settings (optional, uses defaults if not set)
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	ConnMaxIdleTime time.Duration
 }
 
 type Config struct {
@@ -98,6 +109,9 @@ func createConnection(cfg ConnectionConfig) (*Database, error) {
 		if err != nil {
 			return nil, fmt.Errorf("SQLite connection error: %w", err)
 		}
+
+		configureConnectionPool(db, cfg)
+
 		return db, nil
 	case "sqlserver":
 		/**
@@ -167,6 +181,9 @@ func createConnection(cfg ConnectionConfig) (*Database, error) {
 		if err != nil {
 			return nil, fmt.Errorf("SQL Server connection error: %w", err)
 		}
+
+		configureConnectionPool(db, cfg)
+
 		return db, nil
 
 	case "postgres":
@@ -227,6 +244,9 @@ func createConnection(cfg ConnectionConfig) (*Database, error) {
 		if err != nil {
 			return nil, fmt.Errorf("PostgreSQL connection error: %w", err)
 		}
+
+		configureConnectionPool(db, cfg)
+
 		return db, nil
 	default:
 		return nil, fmt.Errorf("unknown database driver %s, supported drivers are [sqlite, sqlserver, postgres]", cfg.Driver)
@@ -240,4 +260,55 @@ func (m *Service) GetDatabase(name string) *Database {
 
 func (m *Service) GetDefault() *Database {
 	return m.databases[DefaultDatabaseName]
+}
+
+func configureConnectionPool(db *Database, cfg ConnectionConfig) {
+	// Get the underlying *sql.DB connection from GORM
+	// See: https://gorm.io/docs/connecting_to_the_database.html#Connection-Pool
+	sqlDB, err := db.DB()
+	if err != nil {
+		return
+	}
+
+	// Determine pool settings, preferring config values over defaults
+	maxOpenConns := cfg.MaxOpenConns
+	if maxOpenConns <= 0 {
+		maxOpenConns = DefaultMaxOpenConns
+	}
+
+	maxIdleConns := cfg.MaxIdleConns
+	if maxIdleConns <= 0 {
+		maxIdleConns = DefaultMaxIdleConns
+	}
+
+	// Ensure MaxIdleConns does not exceed MaxOpenConns
+	if maxIdleConns > maxOpenConns {
+		maxIdleConns = maxOpenConns
+	}
+
+	connMaxLifetime := cfg.ConnMaxLifetime
+	if connMaxLifetime <= 0 {
+		connMaxLifetime = DefaultConnMaxLifetime
+	}
+
+	connMaxIdleTime := cfg.ConnMaxIdleTime
+	if connMaxIdleTime <= 0 {
+		connMaxIdleTime = DefaultConnMaxIdleTime
+	}
+
+	// Configure connection pool
+	// SetMaxOpenConns sets the maximum number of open connections to the database.
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+
+	// SetMaxIdleConns sets the maximum number of connections in the idle connection pool.
+	// It must not exceed MaxOpenConns to maintain correct pool behavior.
+	sqlDB.SetMaxIdleConns(maxIdleConns)
+
+	// SetConnMaxLifetime sets the maximum amount of time a connection may be reused.
+	// This helps prevent connection staleness and resource leaks.
+	sqlDB.SetConnMaxLifetime(connMaxLifetime)
+
+	// SetConnMaxIdleTime sets the maximum amount of time a connection may be idle.
+	// Connections that exceed this duration will be closed and removed from the pool.
+	sqlDB.SetConnMaxIdleTime(connMaxIdleTime)
 }


### PR DESCRIPTION
**Summary**
Menambahkan konfigurasi connection pool di `service.go` untuk semua driver yang didukung (SQLite, SQL Server, PostgreSQL) sehingga aplikasi lain dapat menyesuaikan pool behavior melalui `ConnectionConfig`.

**What Changed?**
1. Menambahkan default pool constants:
- `DefaultMaxOpenConns => 20`
- `DefaultMaxIdleConns => 5`
- `DefaultConnMaxLifetime => 1h`
- `DefaultConnMaxIdleTime => 30m`
2. Menambahkan field baru di `ConnectionConfig`
- `MaxOpenConns`
- `MaxIdleConns`
- `ConnMaxLifetime`
- `ConnMaxIdleTime`
3. Menambahkan `configureConnectionPool` untuk mengatur `sql.DB` pool settings setelah koneksi GORM dibuat
4. Memanggil `configureConnectionPool` di semua path koneksi: SQLite, SQL Server, PostgreSQL
5. Menambahkan fallback default bila nilai pool tidak diset, plus validasi:
- `MaxIdleConns` tidak boleh lebih besar dari `MaxOpenConns`
- nilai `<= 0` menggunakan default

**Why**

1. Kustomisasi pool connection langsung dari config library
2. Memastikan setting pool sesuai standard GORM + `database/sql`
3. Menghindari masalah ketika `max_connections` PostgreSQL rendah dengan menyediakan default yang lebih aman (`20`).